### PR TITLE
feat(cards): adaptar i18n y aplanamiento de cartas en llamadas a la API

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -24,12 +24,7 @@ const Card = memo(forwardRef(({ card, onFavoriteToggle }, ref) => {
   };
 
 
-  const { id, cost, media, atk, def } = card;
-  const langKey = lang === 'es' ? 'Es' : 'En';
-  const name = card[`name${langKey}`];
-  const type = card[`type${langKey}`];
-  const rarity = card[`rarity${langKey}`];
-  const image = media.image;
+  const { id, cost, atk, def, name, type, rarity, image } = card;
   const imageUrl = `${CARDS_URL}${image}`;
   const currentConfig = getRarityConfig(rarity);
   const fallbackImage = `${CARDS_URL}FallbackImage${capitalize(lang)}.webp`;

--- a/src/components/Card.test.jsx
+++ b/src/components/Card.test.jsx
@@ -23,14 +23,13 @@ vi.mock('react-i18next', () => ({
 describe('Card Component', () => {
   const mockCard = {
     id: '1',
-    nameEn: 'Dragon Warrior',
-    nameEs: 'Guerrero Dragón',
-    typeEn: 'Unit',
-    rarityEn: 'Legendary',
+    name: 'Dragon Warrior',
+    type: 'Unit',
+    rarity: 'Legendary',
     cost: 5,
     atk: 10,
     def: 8,
-    media: { image: 'dragon.png' }
+    image: 'dragon.png'
   };
 
   beforeEach(() => {

--- a/src/hooks/useInfiniteCards.js
+++ b/src/hooks/useInfiniteCards.js
@@ -82,13 +82,11 @@ export const useInfiniteCards = ({ limit = 12, initialFilters, lang }) => {
       }
 
       if (filters.selectedTypes.length > 0) {
-        const typeKey = filters.selectedTypes[0];
-        params[`type${langKey}`] = tRef.current(`home.filters.types.${typeKey}`, { lng: lang });
+        params.type = filters.selectedTypes[0];
       }
 
       if (filters.selectedRarities.length > 0) {
-        const rarityKey = filters.selectedRarities[0];
-        params[`rarity${langKey}`] = tRef.current(`home.filters.rarities.${rarityKey}`, { lng: lang });
+        params.rarity = filters.selectedRarities[0];
       }
 
       const data = await cardService.getCards(params, { signal: abortControllerRef.current.signal });

--- a/src/hooks/useInfiniteCards.test.js
+++ b/src/hooks/useInfiniteCards.test.js
@@ -107,7 +107,7 @@ describe('useInfiniteCards Hook', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(cardService.getCards).toHaveBeenCalledWith(
-      expect.objectContaining({ typeEn: 'home.filters.types.unit' }),
+      expect.objectContaining({ type: 'unit' }),
       expect.objectContaining({ signal: expect.anything() })
     );
     expect(result.current.cards).toHaveLength(1);
@@ -129,7 +129,7 @@ describe('useInfiniteCards Hook', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(cardService.getCards).toHaveBeenCalledWith(
-      expect.objectContaining({ rarityEn: 'home.filters.rarities.legendary' }),
+      expect.objectContaining({ rarity: 'legendary' }),
       expect.objectContaining({ signal: expect.anything() })
     );
   });

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -66,13 +66,8 @@ export default function Detail() {
 
   if (!card) return null;
 
-  const langKey = lang === 'es' ? 'Es' : 'En';
-  const name = card[`name${langKey}`];
-  const type = card[`type${langKey}`];
-  const rarity = card[`rarity${langKey}`];
-  const description = card[`description${langKey}`];
-  const { cost, atk, def, media } = card;
-  const imageUrl = `${CARDS_URL}${media.image}`;
+  const { cost, atk, def, name, type, rarity, description, image } = card;
+  const imageUrl = `${CARDS_URL}${image}`;
   const rarityStyle = getRarityConfig(rarity);
 
   return (

--- a/src/pages/Detail.test.jsx
+++ b/src/pages/Detail.test.jsx
@@ -40,18 +40,14 @@ vi.mock('../services/favoritesService', () => ({
 
 const mockCard = {
   id: 'card-1',
-  nameEs: 'Mago de Fuego',
-  nameEn: 'Fire Mage',
-  typeEs: 'Unidad',
-  typeEn: 'Unit',
-  rarityEs: 'Legendario',
-  rarityEn: 'Legendary',
+  name: 'Mago de Fuego',
+  type: 'Unidad',
+  rarity: 'Legendario',
   cost: 5,
   atk: 8,
   def: 6,
-  media: { image: 'fire-mage.webp' },
-  descriptionEs: 'Un poderoso mago del fuego.',
-  descriptionEn: 'A powerful fire mage.',
+  image: 'fire-mage.webp',
+  description: 'Un poderoso mago del fuego.',
 };
 
 function renderDetail() {

--- a/src/pages/Favorites.test.jsx
+++ b/src/pages/Favorites.test.jsx
@@ -29,16 +29,13 @@ vi.mock('../services/favoritesService', () => ({
 
 const mockCard = {
   id: 'card-1',
-  nameEs: 'Mago',
-  nameEn: 'Mage',
-  typeEs: 'Unidad',
-  typeEn: 'Unit',
-  rarityEs: 'Común',
-  rarityEn: 'Common',
+  name: 'Mago',
+  type: 'Unidad',
+  rarity: 'Común',
   cost: 3,
   atk: 5,
   def: 3,
-  media: { image: 'mago.webp' },
+  image: 'mago.webp',
 };
 
 describe('Favorites Page', () => {

--- a/src/services/cardService.js
+++ b/src/services/cardService.js
@@ -16,6 +16,8 @@
  * @property {string} descriptionEn - Descripción en inglés.
  */
 
+import i18n from '../i18n';
+
 const API_URL = import.meta.env.VITE_API_URL;
 
 const cardService = {
@@ -44,7 +46,12 @@ const cardService = {
       });
       url.search = searchParams.toString();
 
-      const response = await fetch(url, { signal });
+      const response = await fetch(url, { 
+        signal,
+        headers: {
+          'Accept-Language': i18n.language || 'es'
+        }
+      });
       
       if (!response.ok) {
         if (response.status === 404) return [];
@@ -69,7 +76,12 @@ const cardService = {
    */
   getCardById: async (id, { signal } = {}) => {
     try {
-      const response = await fetch(`${API_URL}/cards/${id}`, { signal });
+      const response = await fetch(`${API_URL}/cards/${id}`, { 
+        signal,
+        headers: {
+          'Accept-Language': i18n.language || 'es'
+        }
+      });
       
       if (!response.ok) {
         if (response.status === 404) return null;


### PR DESCRIPTION
Closes #78

### Summary
- Adaptación de cardService para enviar idioma en cabecera Accept-Language.
- Aplanamiento de propiedades de cartas en Card y Detail.
- Actualización de mocks y aserciones de la suite de tests unitarios del frontend.