### PR TITLE
feat(favorites): connect favorites to backend API

### DIFF
--- a/Remove-GitLocalBranches.ps1
+++ b/Remove-GitLocalBranches.ps1
@@ -1,0 +1,42 @@
+# Remove-GitLocalBranches.ps1
+# Deletes local branches whose remote counterpart no longer exists (merged and deleted on GitHub).
+
+# 1. Limpiar referencias remotas inactivas
+git fetch --prune | Out-Null
+
+$protected = @('develop', 'main')
+
+# 2. Obtener la rama en la que estamos parados actualmente para protegerla del borrado
+$currentBranch = (git rev-parse --abbrev-ref HEAD).Trim()
+
+# 3. Filtrar y limpiar los nombres de las ramas de forma robusta
+$branches = git branch -vv |
+    Where-Object { $_ -match ': gone\]' } |
+    ForEach-Object {
+        # Quitamos asteriscos y espacios sobrantes del inicio y fin
+        $cleanLine = $_.Replace('*', '').Trim()
+        # El primer elemento tras el split por espacios siempre será el nombre de la rama
+        ($cleanLine -split '\s+')[0]
+    } |
+    Where-Object { $_ -notin $protected -and $_ -ne $currentBranch }
+
+if (-not $branches) {
+    Write-Host "Nothing to clean up — all local branches have a remote counterpart." -ForegroundColor Green
+    exit 0
+}
+
+Write-Host "Branches to delete (excluding protected and current checkout '$currentBranch'):" -ForegroundColor Yellow
+$branches | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
+
+$confirm = Read-Host "`nProceed? (y/N)"
+if ($confirm -ne 'y') {
+    Write-Host "Cancelled." -ForegroundColor Gray
+    exit 0
+}
+
+# Borrado masivo
+$branches | ForEach-Object { 
+    Write-Host "Deleting branch $_..."
+    git branch -D $_ 
+}
+Write-Host "`nDone." -ForegroundColor Green

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -12,14 +12,28 @@ const Card = memo(forwardRef(({ card, onFavoriteToggle }, ref) => {
   const lang = i18n.language.startsWith('es') ? 'es' : 'en';
   const [isFav, setIsFav] = useState(() => favoritesService.isFavorite(card.id));
 
-  const handleFavorite = (e) => {
+  const handleFavorite = async (e) => {
     e.preventDefault();
     e.stopPropagation();
-    favoritesService.toggleFavorite(card);
-    const newIsFav = !isFav;
+    
+    const previousIsFav = isFav;
+    const newIsFav = !previousIsFav;
+
+    // Actualización optimista de la UI
     setIsFav(newIsFav);
     if (onFavoriteToggle) {
       onFavoriteToggle(card, newIsFav);
+    }
+
+    try {
+      await favoritesService.toggleFavorite(card);
+    } catch (error) {
+      console.error('Failed to toggle favorite:', error);
+      // Rollback ante error de la API
+      setIsFav(previousIsFav);
+      if (onFavoriteToggle) {
+        onFavoriteToggle(card, previousIsFav);
+      }
     }
   };
 

--- a/src/components/Card.test.jsx
+++ b/src/components/Card.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import Card from './Card';
@@ -53,8 +53,9 @@ describe('Card Component', () => {
     expect(screen.getByText('Legendary')).toBeInTheDocument();
   });
 
-  it('handles favorite toggle', () => {
+  it('handles favorite toggle and updates optimistically', async () => {
     favoritesService.isFavorite.mockReturnValue(false);
+    favoritesService.toggleFavorite.mockResolvedValueOnce([]); // Resuelve exitoso
     
     render(
       <MemoryRouter>
@@ -65,8 +66,31 @@ describe('Card Component', () => {
     const favButton = screen.getByRole('button', { name: /card.addFavorite/i });
     fireEvent.click(favButton);
 
+    // Debe cambiar optimistamente a "removeFavorite" inmediatamente
+    expect(screen.getByRole('button', { name: /card.removeFavorite/i })).toBeInTheDocument();
     expect(favoritesService.toggleFavorite).toHaveBeenCalledWith(mockCard);
+  });
 
+  it('reverts favorite UI state (rollback) if toggle API fails', async () => {
+    favoritesService.isFavorite.mockReturnValue(false);
+    favoritesService.toggleFavorite.mockRejectedValueOnce(new Error('Toggle Failed'));
+    
+    render(
+      <MemoryRouter>
+        <Card card={mockCard} />
+      </MemoryRouter>
+    );
+
+    const favButton = screen.getByRole('button', { name: /card.addFavorite/i });
+    fireEvent.click(favButton);
+
+    // Setea optimistamente a favorito inmediatamente
+    expect(screen.getByRole('button', { name: /card.removeFavorite/i })).toBeInTheDocument();
+
+    // Pero al fallar el servicio, debe rollbackear a no-favorito
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /card.addFavorite/i })).toBeInTheDocument();
+    });
   });
 
   it('shows "remove favorite" aria-label when card is already favorite', () => {

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useEffect } from 'react';
 import authService from '../services/authService';
+import favoritesService from '../services/favoritesService';
 
 const AuthContext = createContext(null);
 
@@ -17,9 +18,12 @@ export function AuthProvider({ children }) {
           const userData = await authService.getMe(savedToken);
           setToken(savedToken);
           setUser(userData);
+          // Cargar favoritos en cache al restaurar sesión
+          await favoritesService.fetchFavorites();
         } catch (error) {
           console.error('Session restoration failed:', error);
           localStorage.removeItem('hexa_token');
+          favoritesService.clearFavorites();
         }
       }
       setLoading(false);
@@ -27,13 +31,14 @@ export function AuthProvider({ children }) {
     restoreSession();
   }, []);
 
-  // Escuchar evento global de expiracion de sesion (US13)
+  // Escuchar evento global de expiracion de sesion
   useEffect(() => {
     const handleAuthExpired = () => {
       console.warn('Session expired event received, cleaning up local state');
       localStorage.removeItem('hexa_token');
       setToken(null);
       setUser(null);
+      favoritesService.clearFavorites();
     };
 
     window.addEventListener('auth:expired', handleAuthExpired);
@@ -66,6 +71,8 @@ export function AuthProvider({ children }) {
       localStorage.setItem('hexa_token', result.token);
       setToken(result.token);
       setUser(result.user);
+      // Cargar favoritos en cache al iniciar sesión
+      await favoritesService.fetchFavorites();
       setLoading(false);
       return result;
     } catch (error) {
@@ -87,6 +94,7 @@ export function AuthProvider({ children }) {
       localStorage.removeItem('hexa_token');
       setToken(null);
       setUser(null);
+      favoritesService.clearFavorites();
       setLoading(false);
     }
   };

--- a/src/context/AuthContext.test.jsx
+++ b/src/context/AuthContext.test.jsx
@@ -3,10 +3,17 @@ import { render, act } from '@testing-library/react';
 import { useEffect } from 'react';
 import { AuthProvider, useAuth } from './AuthContext';
 import authService from '../services/authService';
+import favoritesService from '../services/favoritesService';
 
 vi.mock('../services/authService');
+vi.mock('../services/favoritesService', () => ({
+  default: {
+    fetchFavorites: vi.fn().mockResolvedValue([]),
+    clearFavorites: vi.fn()
+  }
+}));
 
-// Componente helper para interactuar con useAuth en los tests
+// Helper component
 function TestComponent({ onMount }) {
   const auth = useAuth();
   useEffect(() => {
@@ -27,11 +34,10 @@ function TestComponent({ onMount }) {
 describe('AuthContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
-  it('debe inicializar con user en null y loading en false por defecto', async () => {
-    authService.getMe.mockRejectedValueOnce(new Error('No session'));
-
+  it('debe inicializar con user en null y loading en false por defecto si no hay token', async () => {
     let authInstance;
     await act(async () => {
       render(
@@ -44,9 +50,30 @@ describe('AuthContext', () => {
     expect(authInstance.user).toBeNull();
     expect(authInstance.loading).toBe(false);
     expect(authInstance.isAuthenticated).toBe(false);
+    expect(favoritesService.fetchFavorites).not.toHaveBeenCalled();
   });
 
-  it('debe iniciar sesion correctamente al llamar a login', async () => {
+  it('debe restaurar la sesion y cargar favoritos si hay token en localStorage', async () => {
+    const mockUser = { id: 1, email: 'test@test.com', role: 'usuario' };
+    localStorage.setItem('hexa_token', 'saved-jwt-token');
+    authService.getMe.mockResolvedValueOnce(mockUser);
+
+    let authInstance;
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <TestComponent onMount={(auth) => { authInstance = auth; }} />
+        </AuthProvider>
+      );
+    });
+
+    expect(authService.getMe).toHaveBeenCalledWith('saved-jwt-token');
+    expect(authInstance.user).toEqual(mockUser);
+    expect(authInstance.isAuthenticated).toBe(true);
+    expect(favoritesService.fetchFavorites).toHaveBeenCalled();
+  });
+
+  it('debe iniciar sesion correctamente al llamar a login y cargar favoritos', async () => {
     const mockUser = { id: 1, email: 'test@test.com', role: 'usuario' };
     const mockLoginResponse = { token: 'jwt-token', user: mockUser };
     
@@ -67,9 +94,10 @@ describe('AuthContext', () => {
     expect(authService.login).toHaveBeenCalledWith('test@test.com', 'password123');
     expect(authInstance.user).toEqual(mockUser);
     expect(authInstance.isAuthenticated).toBe(true);
+    expect(favoritesService.fetchFavorites).toHaveBeenCalled();
   });
 
-  it('debe lanzar error y mantener al usuario en null si login falla', async () => {
+  it('debe lanzar error y mantener al usuario en null si login falla sin cargar favoritos', async () => {
     authService.login.mockRejectedValueOnce(new Error('Invalid credentials'));
 
     let authInstance;
@@ -87,9 +115,10 @@ describe('AuthContext', () => {
 
     expect(authInstance.user).toBeNull();
     expect(authInstance.isAuthenticated).toBe(false);
+    expect(favoritesService.fetchFavorites).not.toHaveBeenCalled();
   });
 
-  it('debe cerrar sesion correctamente al llamar a logout', async () => {
+  it('debe cerrar sesion correctamente al llamar a logout y limpiar favoritos', async () => {
     authService.logout.mockResolvedValueOnce(true);
 
     let authInstance;
@@ -99,8 +128,6 @@ describe('AuthContext', () => {
       </AuthProvider>
     );
 
-    // Simulamos que el usuario ya estaba autenticado seteandolo manualmente o iniciando sesion
-    // En este caso, usaremos el mock de login primero
     const mockUser = { id: 1, email: 'test@test.com', role: 'usuario' };
     authService.login.mockResolvedValueOnce({ token: 'jwt-token', user: mockUser });
     
@@ -109,8 +136,8 @@ describe('AuthContext', () => {
     });
 
     expect(authInstance.user).toEqual(mockUser);
+    vi.clearAllMocks(); // Limpiar llamadas previas (del login)
 
-    // Ahora cerramos sesion
     await act(async () => {
       await authInstance.logout();
     });
@@ -118,5 +145,6 @@ describe('AuthContext', () => {
     expect(authService.logout).toHaveBeenCalled();
     expect(authInstance.user).toBeNull();
     expect(authInstance.isAuthenticated).toBe(false);
+    expect(favoritesService.clearFavorites).toHaveBeenCalled();
   });
 });

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -49,10 +49,21 @@ export default function Detail() {
     return () => controller.abort();
   }, [id, navigate, i18n.language]);
 
-  const handleFavorite = () => {
+  const handleFavorite = async () => {
     if (card) {
-      favoritesService.toggleFavorite(card);
-      setIsFav(!isFav);
+      const previousIsFav = isFav;
+      const newIsFav = !previousIsFav;
+      
+      // Actualización optimista de la UI
+      setIsFav(newIsFav);
+      
+      try {
+        await favoritesService.toggleFavorite(card);
+      } catch (error) {
+        console.error('Failed to toggle favorite in details:', error);
+        // Rollback ante error de la API
+        setIsFav(previousIsFav);
+      }
     }
   };
 

--- a/src/pages/Detail.test.jsx
+++ b/src/pages/Detail.test.jsx
@@ -110,9 +110,10 @@ describe('Detail Page', () => {
     });
   });
 
-  it('alterna el favorito al hacer clic en el corazón', async () => {
+  it('alterna el favorito al hacer clic en el corazón optimistamente', async () => {
     cardService.getCardById.mockResolvedValue(mockCard);
     favoritesService.isFavorite.mockReturnValue(false);
+    favoritesService.toggleFavorite.mockResolvedValueOnce([]); // Resuelve ok
 
     renderDetail();
 
@@ -121,10 +122,41 @@ describe('Detail Page', () => {
     });
 
     const favButton = screen.getByRole('button');
+    
+    // Al principio no es favorito (color original en la UI)
+    expect(favButton).not.toHaveClass('bg-red-500'); // Asumimos color por defecto
+
     fireEvent.click(favButton);
 
+    // Cambia optimistamente
     expect(favoritesService.toggleFavorite).toHaveBeenCalledWith(mockCard);
+  });
 
+  it('reverts favorite UI state (rollback) in detail page if toggle API fails', async () => {
+    cardService.getCardById.mockResolvedValue(mockCard);
+    favoritesService.isFavorite.mockReturnValue(false);
+    favoritesService.toggleFavorite.mockRejectedValueOnce(new Error('API Toggle Failed'));
+
+    renderDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Mago de Fuego')).toBeInTheDocument();
+    });
+
+    const favButton = screen.getByRole('button');
+    
+    // Al principio no es favorito
+    expect(favButton).toHaveClass('text-slate-400');
+
+    fireEvent.click(favButton);
+
+    // Se asume optimismo visual (cambia inmediatamente a bg-red-500/90)
+    expect(favButton).toHaveClass('bg-red-500/90');
+
+    // Pero al fallar el servicio, debe rollbackear a no-favorito
+    await waitFor(() => {
+      expect(favButton).toHaveClass('text-slate-400');
+    });
   });
 
   it('muestra imagen de fallback si la imagen principal falla', async () => {

--- a/src/pages/Favorites.jsx
+++ b/src/pages/Favorites.jsx
@@ -6,13 +6,13 @@ import Card from '../components/Card';
 import LoadingSpinner from '../components/LoadingSpinner';
 
 export default function Favorites() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const [favorites, setFavorites] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  // Obtener favoritos desde la API al montar
+  // Obtener favoritos desde la API al montar o cambiar el idioma
   useEffect(() => {
     const fetchFavoritesData = async () => {
       try {
@@ -28,7 +28,7 @@ export default function Favorites() {
       }
     };
     fetchFavoritesData();
-  }, []);
+  }, [i18n.language]);
 
   // Callback para remover la carta de la vista cuando se desmarca
   const handleFavoriteToggle = useCallback((card, isFav) => {

--- a/src/pages/Favorites.jsx
+++ b/src/pages/Favorites.jsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useState, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import favoritesService from '../services/favoritesService';
 import Card from '../components/Card';
@@ -8,20 +8,58 @@ import LoadingSpinner from '../components/LoadingSpinner';
 export default function Favorites() {
   const { t } = useTranslation();
 
-  // Los favoritos ya vienen como objetos completos desde el servicio (LocalStorage)
-  // Cargamos directamente en el estado inicial
-  const [favorites, setFavorites] = useState(() => favoritesService.getFavorites());
+  const [favorites, setFavorites] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // Obtener favoritos desde la API al montar
+  useEffect(() => {
+    const fetchFavoritesData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        await favoritesService.fetchFavorites();
+        setFavorites(favoritesService.getFavorites());
+      } catch (err) {
+        console.error('Failed to fetch favorites page data:', err);
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchFavoritesData();
+  }, []);
 
   // Callback para remover la carta de la vista cuando se desmarca
   const handleFavoriteToggle = useCallback((card, isFav) => {
     if (!isFav) {
-      setFavorites(prevFavorites => prevFavorites.filter(c => c.id !== card.id));
+      setFavorites(prevFavorites => prevFavorites.filter(c => String(c.id) !== String(card.id)));
     }
   }, []);
 
+  if (loading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center py-12">
+        <LoadingSpinner message={t('favorites.loading')} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="py-12">
+        <div className="rounded-xl border border-red-200 bg-red-50/50 py-16 text-center dark:border-red-950/30 dark:bg-red-950/10">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="mx-auto mb-4 h-16 w-16 text-red-500/70">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+          </svg>
+          <p className="text-lg text-red-600 dark:text-red-400">{t('favorites.error')}</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="py-12">
-
       <header className="mb-12">
         <h1 className="mb-4 text-4xl font-extrabold text-slate-900 dark:text-slate-100">
           {t('favorites.title')}

--- a/src/pages/Favorites.test.jsx
+++ b/src/pages/Favorites.test.jsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import Favorites from './Favorites';
 import favoritesService from '../services/favoritesService';
 
+const mockLanguage = vi.hoisted(() => ({ value: 'es' }));
 const mockT = vi.hoisted(() => (str) => str);
 
 vi.mock('react-i18next', () => ({
@@ -11,7 +12,7 @@ vi.mock('react-i18next', () => ({
     t: mockT,
     i18n: {
       changeLanguage: () => new Promise(() => {}),
-      language: 'es'
+      language: mockLanguage.value
     },
   }),
   initReactI18next: {
@@ -42,10 +43,10 @@ const mockCard = {
 describe('Favorites Page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLanguage.value = 'es';
   });
 
   it('muestra spinner de carga mientras se obtienen los favoritos', () => {
-    // La promesa queda pendiente
     favoritesService.fetchFavorites.mockReturnValueOnce(new Promise(() => {}));
     favoritesService.getFavorites.mockReturnValue([]);
 
@@ -68,7 +69,6 @@ describe('Favorites Page', () => {
       </MemoryRouter>
     );
 
-    // Esperar a que se quite el estado de carga y muestre error
     await waitFor(() => {
       expect(screen.queryByText('favorites.loading')).not.toBeInTheDocument();
     });
@@ -108,5 +108,35 @@ describe('Favorites Page', () => {
       expect(screen.queryByText('favorites.loading')).not.toBeInTheDocument();
     });
     expect(screen.getByText('Mago')).toBeInTheDocument();
+  });
+
+  it('vuelve a solicitar los favoritos al cambiar el idioma (i18n)', async () => {
+    favoritesService.fetchFavorites.mockResolvedValue([mockCard]);
+    favoritesService.getFavorites.mockReturnValue([mockCard]);
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <Favorites />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(favoritesService.fetchFavorites).toHaveBeenCalledTimes(1);
+    });
+
+    // Cambiar idioma en mock
+    mockLanguage.value = 'en';
+
+    // Rerenderizar para propagar el cambio de idioma
+    rerender(
+      <MemoryRouter>
+        <Favorites />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      // Debería haberse llamado por segunda vez para obtener los datos en inglés
+      expect(favoritesService.fetchFavorites).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/src/pages/Favorites.test.jsx
+++ b/src/pages/Favorites.test.jsx
@@ -22,6 +22,7 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('../services/favoritesService', () => ({
   default: {
+    fetchFavorites: vi.fn(),
     getFavorites: vi.fn(),
     isFavorite: vi.fn(),
   },
@@ -43,7 +44,39 @@ describe('Favorites Page', () => {
     vi.clearAllMocks();
   });
 
+  it('muestra spinner de carga mientras se obtienen los favoritos', () => {
+    // La promesa queda pendiente
+    favoritesService.fetchFavorites.mockReturnValueOnce(new Promise(() => {}));
+    favoritesService.getFavorites.mockReturnValue([]);
+
+    render(
+      <MemoryRouter>
+        <Favorites />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('favorites.loading')).toBeInTheDocument();
+  });
+
+  it('muestra mensaje de error si falla la llamada a la API', async () => {
+    favoritesService.fetchFavorites.mockRejectedValueOnce(new Error('API Error'));
+    favoritesService.getFavorites.mockReturnValue([]);
+
+    render(
+      <MemoryRouter>
+        <Favorites />
+      </MemoryRouter>
+    );
+
+    // Esperar a que se quite el estado de carga y muestre error
+    await waitFor(() => {
+      expect(screen.queryByText('favorites.loading')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('favorites.error')).toBeInTheDocument();
+  });
+
   it('muestra mensaje de lista vacía cuando no hay favoritos', async () => {
+    favoritesService.fetchFavorites.mockResolvedValueOnce([]);
     favoritesService.getFavorites.mockReturnValue([]);
 
     render(
@@ -53,15 +86,16 @@ describe('Favorites Page', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('favorites.empty')).toBeInTheDocument();
+      expect(screen.queryByText('favorites.loading')).not.toBeInTheDocument();
     });
+    expect(screen.getByText('favorites.empty')).toBeInTheDocument();
     expect(screen.getByText('favorites.emptySub')).toBeInTheDocument();
     const link = screen.getByRole('link', { name: 'favorites.backToCatalog' });
     expect(link).toHaveAttribute('href', '/');
   });
 
-  it('renderiza las cartas favoritas en un grid', async () => {
-    // Ahora el servicio devuelve objetos completos
+  it('renderiza las cartas favoritas en un grid tras carga exitosa', async () => {
+    favoritesService.fetchFavorites.mockResolvedValueOnce([mockCard]);
     favoritesService.getFavorites.mockReturnValue([mockCard]);
 
     render(
@@ -71,7 +105,8 @@ describe('Favorites Page', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Mago')).toBeInTheDocument();
+      expect(screen.queryByText('favorites.loading')).not.toBeInTheDocument();
     });
+    expect(screen.getByText('Mago')).toBeInTheDocument();
   });
 });

--- a/src/services/favoritesService.js
+++ b/src/services/favoritesService.js
@@ -1,54 +1,85 @@
-import storageService from './storageService';
+import apiClient from './apiClient';
 
-const FAVORITES_KEY = 'hexa_favorites';
+let cachedFavorites = [];
 
 /**
  * Servicio para gestionar la persistencia de las cartas favoritas del usuario.
- * Ahora guarda el objeto completo de la carta para evitar N+1 requests.
+ * Ahora se conecta con el backend e implementa un cache en memoria para evitar
+ * consultas N+1 en el renderizado de cartas.
  */
 const favoritesService = {
   /**
-   * Obtiene el listado de objetos de cartas favoritas.
+   * Inicializa y obtiene el caché desde el backend.
+   * @returns {Promise<Object[]>}
+   */
+  fetchFavorites: async () => {
+    try {
+      cachedFavorites = await apiClient.get('/favorites') || [];
+      return cachedFavorites;
+    } catch (error) {
+      cachedFavorites = [];
+      throw error;
+    }
+  },
+
+  /**
+   * Obtiene el listado de objetos de cartas favoritas desde el caché local.
    * @returns {Object[]}
    */
   getFavorites: () => {
-    return storageService.get(FAVORITES_KEY) || [];
+    return cachedFavorites;
   },
 
   /**
    * Agrega una carta a favoritos.
    * @param {Object} card - Objeto completo de la carta.
-   * @returns {Object[]} - Lista actualizada de favoritos.
+   * @returns {Promise<Object[]>} - Lista actualizada de favoritos.
    */
-  addFavorite: (card) => {
-    const favorites = favoritesService.getFavorites();
-    if (!favorites.some(f => f.id === card.id)) {
-      favorites.push(card);
-      storageService.set(FAVORITES_KEY, favorites);
+  addFavorite: async (card) => {
+    // Agregar optimistamente
+    if (!cachedFavorites.some(f => String(f.id) === String(card.id))) {
+      cachedFavorites.push(card);
     }
-    return favorites;
+
+    try {
+      await apiClient.post('/favorites', { cardId: card.id });
+    } catch (error) {
+      // Rollback ante fallo de API
+      cachedFavorites = cachedFavorites.filter(f => String(f.id) !== String(card.id));
+      throw error;
+    }
+
+    return cachedFavorites;
   },
 
   /**
    * Elimina una carta de favoritos.
-   * @param {string} cardId 
-   * @returns {Object[]} - Lista actualizada de favoritos.
+   * @param {string|number} cardId 
+   * @returns {Promise<Object[]>} - Lista actualizada de favoritos.
    */
-  removeFavorite: (cardId) => {
-    const favorites = favoritesService.getFavorites();
-    const filtered = favorites.filter(f => f.id !== cardId);
-    storageService.set(FAVORITES_KEY, filtered);
-    return filtered;
+  removeFavorite: async (cardId) => {
+    const originalFavorites = [...cachedFavorites];
+    // Eliminar optimistamente
+    cachedFavorites = cachedFavorites.filter(f => String(f.id) !== String(cardId));
+
+    try {
+      await apiClient.delete(`/favorites/${cardId}`);
+    } catch (error) {
+      // Rollback ante fallo de API
+      cachedFavorites = originalFavorites;
+      throw error;
+    }
+
+    return cachedFavorites;
   },
 
   /**
    * Alterna el estado de favorito de una carta.
    * @param {Object} card - Objeto completo de la carta.
-   * @returns {Object[]} - Lista actualizada de favoritos.
+   * @returns {Promise<Object[]>} - Lista actualizada de favoritos.
    */
-  toggleFavorite: (card) => {
-    const favorites = favoritesService.getFavorites();
-    if (favorites.some(f => f.id === card.id)) {
+  toggleFavorite: async (card) => {
+    if (favoritesService.isFavorite(card.id)) {
       return favoritesService.removeFavorite(card.id);
     } else {
       return favoritesService.addFavorite(card);
@@ -56,20 +87,19 @@ const favoritesService = {
   },
 
   /**
-   * Verifica si una carta es favorita por su ID.
-   * @param {string} cardId 
+   * Verifica si una carta es favorita por su ID de forma sincrónica.
+   * @param {string|number} cardId 
    * @returns {boolean}
    */
   isFavorite: (cardId) => {
-    const favorites = favoritesService.getFavorites();
-    return favorites.some(f => f.id === cardId);
+    return cachedFavorites.some(f => String(f.id) === String(cardId));
   },
 
   /**
-   * Limpia todos los favoritos.
+   * Limpia todos los favoritos del caché en memoria.
    */
   clearFavorites: () => {
-    storageService.set(FAVORITES_KEY, []);
+    cachedFavorites = [];
   }
 };
 

--- a/src/services/favoritesService.test.js
+++ b/src/services/favoritesService.test.js
@@ -1,101 +1,144 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import favoritesService from './favoritesService';
-import storageService from './storageService';
+import apiClient from './apiClient';
 
-
-vi.mock('./storageService', () => ({
+vi.mock('./apiClient', () => ({
   default: {
     get: vi.fn(),
-    set: vi.fn()
+    post: vi.fn(),
+    delete: vi.fn()
   }
 }));
 
-describe('favoritesService', () => {
+describe('favoritesService with API Integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    favoritesService.clearFavorites();
   });
 
-  describe('getFavorites', () => {
-    it('retorna un array vacio si no hay favoritos guardados', () => {
-      storageService.get.mockReturnValueOnce(null);
-      expect(favoritesService.getFavorites()).toEqual([]);
-    });
+  describe('fetchFavorites', () => {
+    it('llama a la API GET /favorites y llena el cache', async () => {
+      const mockFavorites = [{ id: '1', name: 'Card 1' }, { id: 2, name: 'Card 2' }];
+      apiClient.get.mockResolvedValueOnce(mockFavorites);
 
-    it('retorna la lista de favoritos guardados', () => {
-      const mockFavorites = [{ id: 'card-1' }, { id: 'card-2' }];
-      storageService.get.mockReturnValueOnce(mockFavorites);
+      const result = await favoritesService.fetchFavorites();
+
+      expect(apiClient.get).toHaveBeenCalledWith('/favorites');
+      expect(result).toEqual(mockFavorites);
       expect(favoritesService.getFavorites()).toEqual(mockFavorites);
     });
-  });
 
-  describe('addFavorite', () => {
-    it('agrega un objeto de carta completo a la lista de favoritos', () => {
-      const mockCard1 = { id: 'card-1', nameEn: 'Card 1' };
-      const mockCard2 = { id: 'card-2', nameEn: 'Card 2' };
-      storageService.get.mockReturnValueOnce([mockCard1]);
-      
-      const result = favoritesService.addFavorite(mockCard2);
+    it('limpia el cache y propaga el error si falla la API', async () => {
+      const mockError = new Error('API Error');
+      apiClient.get.mockRejectedValueOnce(mockError);
 
-      expect(result).toEqual([mockCard1, mockCard2]);
-      expect(storageService.set).toHaveBeenCalledWith('hexa_favorites', [mockCard1, mockCard2]);
-    });
+      // Metemos algo en el cache antes para probar que se limpie
+      apiClient.post.mockResolvedValueOnce({});
+      await favoritesService.addFavorite({ id: '1', name: 'Card 1' });
 
-    it('no duplica el objeto si el id ya se encuentra en favoritos', () => {
-      const mockCard1 = { id: 'card-1', nameEn: 'Card 1' };
-      storageService.get.mockReturnValueOnce([mockCard1]);
-      
-      const result = favoritesService.addFavorite(mockCard1);
-
-      expect(result).toEqual([mockCard1]);
-      expect(storageService.set).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('removeFavorite', () => {
-    it('elimina un objeto por id de la lista', () => {
-      const mockCard1 = { id: 'card-1' };
-      const mockCard2 = { id: 'card-2' };
-      storageService.get.mockReturnValueOnce([mockCard1, mockCard2]);
-      
-      const result = favoritesService.removeFavorite('card-1');
-
-      expect(result).toEqual([mockCard2]);
-      expect(storageService.set).toHaveBeenCalledWith('hexa_favorites', [mockCard2]);
-    });
-  });
-
-  describe('toggleFavorite', () => {
-    it('agrega la carta si no es favorita actualmente', () => {
-      const mockCard1 = { id: 'card-1' };
-      storageService.get.mockReturnValueOnce([]);
-      favoritesService.toggleFavorite(mockCard1);
-      expect(storageService.set).toHaveBeenCalledWith('hexa_favorites', [mockCard1]);
-    });
-
-    it('remueve la carta si ya es favorita', () => {
-      const mockCard1 = { id: 'card-1' };
-      storageService.get.mockReturnValueOnce([mockCard1]);
-      favoritesService.toggleFavorite(mockCard1);
-      expect(storageService.set).toHaveBeenCalledWith('hexa_favorites', []);
+      await expect(favoritesService.fetchFavorites()).rejects.toThrow('API Error');
+      expect(favoritesService.getFavorites()).toEqual([]);
     });
   });
 
   describe('isFavorite', () => {
-    it('retorna true si el id esta en la lista de objetos', () => {
-      storageService.get.mockReturnValueOnce([{ id: 'card-1' }]);
-      expect(favoritesService.isFavorite('card-1')).toBe(true);
+    it('retorna true si el ID de la carta coincide con el cache (seguro de tipo string)', async () => {
+      const mockFavorites = [{ id: 1 }, { id: '2' }];
+      apiClient.get.mockResolvedValueOnce(mockFavorites);
+      
+      // Llenamos el cache esperando a que termine la promesa
+      await favoritesService.fetchFavorites();
+      
+      expect(favoritesService.isFavorite('1')).toBe(true);
+      expect(favoritesService.isFavorite(1)).toBe(true);
+      expect(favoritesService.isFavorite('2')).toBe(true);
+      expect(favoritesService.isFavorite(2)).toBe(true);
     });
 
-    it('retorna false si el id no esta en la lista', () => {
-      storageService.get.mockReturnValueOnce([{ id: 'card-2' }]);
-      expect(favoritesService.isFavorite('card-1')).toBe(false);
+    it('retorna false si el ID no esta en el cache', () => {
+      expect(favoritesService.isFavorite('99')).toBe(false);
     });
   });
 
-  describe('clearFavorites', () => {
-    it('limpia por completo el array de favoritos', () => {
-      favoritesService.clearFavorites();
-      expect(storageService.set).toHaveBeenCalledWith('hexa_favorites', []);
+  describe('addFavorite', () => {
+    it('agrega optimistamente la carta al cache y hace POST a la API', async () => {
+      const card = { id: 3, name: 'Card 3' };
+      apiClient.post.mockResolvedValueOnce({ message: 'Success' });
+
+      const promise = favoritesService.addFavorite(card);
+      
+      // La UI/Cache debería actualizarse inmediatamente antes de que resuelva el POST
+      expect(favoritesService.isFavorite(3)).toBe(true);
+
+      const result = await promise;
+      expect(apiClient.post).toHaveBeenCalledWith('/favorites', { cardId: 3 });
+      expect(result).toEqual([card]);
+    });
+
+    it('revierte el cache (rollback) si el POST falla', async () => {
+      const card = { id: 4, name: 'Card 4' };
+      apiClient.post.mockRejectedValueOnce(new Error('Network Error'));
+
+      await expect(favoritesService.addFavorite(card)).rejects.toThrow('Network Error');
+      
+      // Debe haber vuelto a falso
+      expect(favoritesService.isFavorite(4)).toBe(false);
+    });
+  });
+
+  describe('removeFavorite', () => {
+    it('remueve optimistamente la carta del cache y hace DELETE a la API', async () => {
+      const card = { id: '5', name: 'Card 5' };
+      apiClient.post.mockResolvedValueOnce({});
+      await favoritesService.addFavorite(card);
+
+      apiClient.delete.mockResolvedValueOnce({ message: 'Deleted' });
+
+      const promise = favoritesService.removeFavorite('5');
+
+      // Eliminación optimista en el cache
+      expect(favoritesService.isFavorite('5')).toBe(false);
+
+      await promise;
+      expect(apiClient.delete).toHaveBeenCalledWith('/favorites/5');
+      expect(favoritesService.getFavorites()).toEqual([]);
+    });
+
+    it('revierte el cache (rollback) si el DELETE falla', async () => {
+      const card = { id: 6, name: 'Card 6' };
+      apiClient.post.mockResolvedValueOnce({});
+      await favoritesService.addFavorite(card);
+
+      apiClient.delete.mockRejectedValueOnce(new Error('Delete Failed'));
+
+      await expect(favoritesService.removeFavorite(6)).rejects.toThrow('Delete Failed');
+
+      // Debe volver a estar en favoritos
+      expect(favoritesService.isFavorite(6)).toBe(true);
+    });
+  });
+
+  describe('toggleFavorite', () => {
+    it('llama a addFavorite si la carta no es favorita', async () => {
+      const card = { id: 7 };
+      apiClient.post.mockResolvedValueOnce({});
+
+      await favoritesService.toggleFavorite(card);
+
+      expect(apiClient.post).toHaveBeenCalledWith('/favorites', { cardId: 7 });
+      expect(favoritesService.isFavorite(7)).toBe(true);
+    });
+
+    it('llama a removeFavorite si la carta ya es favorita', async () => {
+      const card = { id: 8 };
+      apiClient.post.mockResolvedValueOnce({});
+      await favoritesService.addFavorite(card);
+
+      apiClient.delete.mockResolvedValueOnce({});
+      await favoritesService.toggleFavorite(card);
+
+      expect(apiClient.delete).toHaveBeenCalledWith('/favorites/8');
+      expect(favoritesService.isFavorite(8)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Closes #77

### PR Type
- [x] New feature

### Summary
* Connects the favorites system to the backend Express/Prisma API (US7).
* Implements an in-memory cache to prevent N+1 queries during card lists.
* Adds optimistic UI updates on Card and Detail toggles with robust try/catch rollback.
* Integrates favorites caching into session states (AuthContext login/restore/logout).
* Ensures language changes trigger active favorites re-querying (i18n connection).

### Changes
| File | Change |
|------|--------|
| `src/services/favoritesService.js` | Refactored to use `apiClient` with an in-memory cache. |
| `src/services/favoritesService.test.js` | Updated with async TDD tests. |
| `src/context/AuthContext.jsx` | Wired favorites loading and cleaning on session events. |
| `src/context/AuthContext.test.jsx` | Updated test suites to cover favorites. |
| `src/components/Card.jsx` & `Detail.jsx` | Updated to async optimistic toggling with rollbacks. |
| `src/pages/Favorites.jsx` | Rewritten to load async on mount and language switch. |
| `Remove-GitLocalBranches.ps1` | Added helper script for git cleanup. |

### Test Plan
- [x] All 249 unit and integration tests passing successfully.
- [x] ESLint checks completed without failures.
- [x] Verified manually on local environment.
