### PR TITLE
chore(i18n): remover traducciones estaticas de tipos y rarezas en locales

### DIFF
--- a/src/components/CardStatsGrid.test.jsx
+++ b/src/components/CardStatsGrid.test.jsx
@@ -11,12 +11,12 @@ vi.mock('react-i18next', () => ({
 
 describe('CardStatsGrid Component', () => {
   const typeOptions = [
-    { id: 1, labelKey: 'card.types.creature' },
-    { id: 2, labelKey: 'card.types.spell' }
+    { id: 1, name: 'Criatura', labelKey: 'card.types.creature' },
+    { id: 2, name: 'Hechizo', labelKey: 'card.types.spell' }
   ];
   const rarityOptions = [
-    { id: 1, labelKey: 'card.rarities.poor' },
-    { id: 2, labelKey: 'card.rarities.common' }
+    { id: 1, name: 'Pobre', labelKey: 'card.rarities.poor' },
+    { id: 2, name: 'Común', labelKey: 'card.rarities.common' }
   ];
 
   const mockSetCost = vi.fn();

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -20,22 +20,7 @@
     "noResults": "No results found",
     "error": "Could not load the card catalog. Please try again later.",
     "retry": "Retry",
-    "endOfCatalog": "You have reached the end of HEXA.",
-    "filters": {
-      "types": {
-        "creature": "Creature",
-        "spell": "Spell",
-        "artifact": "Artifact"
-      },
-      "rarities": {
-        "poor": "Poor",
-        "common": "Common",
-        "uncommon": "Uncommon",
-        "rare": "Rare",
-        "epic": "Epic",
-        "legendary": "Legendary"
-      }
-    }
+    "endOfCatalog": "You have reached the end of HEXA."
   },
   "detail": {
     "loading": "Summoning card from HEXA...",
@@ -66,19 +51,6 @@
   "card": {
     "addFavorite": "Add to favorites",
     "removeFavorite": "Remove from favorites",
-    "types": {
-      "creature": "Creature",
-      "spell": "Spell",
-      "artifact": "Artifact"
-    },
-    "rarities": {
-      "poor": "Poor",
-      "common": "Common",
-      "uncommon": "Uncommon",
-      "rare": "Rare",
-      "epic": "Epic",
-      "legendary": "Legendary"
-    },
     "admin": {
       "newCard": "New Card",
       "editCard": "Edit Card",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -20,22 +20,7 @@
     "noResults": "No se encontraron resultados",
     "error": "No se pudo cargar el catálogo de cartas. Por favor, reintenta más tarde.",
     "retry": "Reintentar",
-    "endOfCatalog": "Has llegado al final de HEXA.",
-    "filters": {
-      "types": {
-        "creature": "Criatura",
-        "spell": "Hechizo",
-        "artifact": "Artefacto"
-      },
-      "rarities": {
-        "poor": "Pobre",
-        "common": "Común",
-        "uncommon": "Poco Común",
-        "rare": "Raro",
-        "epic": "Épico",
-        "legendary": "Legendario"
-      }
-    }
+    "endOfCatalog": "Has llegado al final de HEXA."
   },
   "detail": {
     "loading": "Invocando carta de HEXA...",
@@ -66,19 +51,6 @@
   "card": {
     "addFavorite": "Agregar a favoritos",
     "removeFavorite": "Eliminar de favoritos",
-    "types": {
-      "creature": "Criatura",
-      "spell": "Hechizo",
-      "artifact": "Artefacto"
-    },
-    "rarities": {
-      "poor": "Pobre",
-      "common": "Común",
-      "uncommon": "Poco Común",
-      "rare": "Raro",
-      "epic": "Épico",
-      "legendary": "Legendario"
-    },
     "admin": {
       "newCard": "Nueva Carta",
       "editCard": "Editar Carta",


### PR DESCRIPTION
Closes #110

### Descripción
Remueve las traducciones estáticas obsoletas de tipos y rarezas en el frontend, ya que se leen dinámicamente de la API del backend.

### Cambios
- Removidos bloques obsoletos en es.json y en.json.
- Actualizados mocks de CardStatsGrid.test.jsx.